### PR TITLE
Add backend request error log messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Version number
-const Version = "0.13.1"
+const Version = "0.13.2"
 
 var message = `<!DOCTYPE html><html>
 <head>

--- a/main.go
+++ b/main.go
@@ -45,6 +45,10 @@ type ConnectionErrorHandler struct{ http.RoundTripper }
 
 func (c *ConnectionErrorHandler) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := c.RoundTripper.RoundTrip(req)
+	if err != nil {
+		log.Printf("Error: backend request failed for %v: %v",
+			req.RemoteAddr, err)
+	}
 	if _, ok := err.(*net.OpError); ok {
 		r := &http.Response{
 			StatusCode: http.StatusServiceUnavailable,


### PR DESCRIPTION
This log reasons that the backend request fails. Useful for
understanding why requests are failing.

```
2018/02/22 10:20:10 Error: backend request failed for [::1]:37620: dial tcp [::1]:80: connect: connection refused
2018/02/22 10:20:10           [::1]:37620 503          0        364 1.4ms  GET /                              curl/7.47.0
```