### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/proxyprotocol/http.go
+++ b/proxyprotocol/http.go
@@ -59,7 +59,7 @@ func BehindTCPProxyListenAndServeTLS(srv *http.Server, certFile, keyFile string)
 	return srv.Serve(listener)
 }
 
-// ListenAndServe listens on the TCP network address srv.Addr and then
+// BehindTCPProxyListenAndServe listens on the TCP network address srv.Addr and then
 // calls Serve to handle requests on incoming connections.  If
 // srv.Addr is blank, ":http" is used.
 func BehindTCPProxyListenAndServe(srv *http.Server) error {

--- a/proxyprotocol/proxy.go
+++ b/proxyprotocol/proxy.go
@@ -116,7 +116,7 @@ func (c *Conn) Read(bs []byte) (int, error) {
 	return c.Reader.Read(bs)
 }
 
-// Return the specified local addr, if there is one.
+// LocalAddr returns the specified local addr, if there is one.
 func (c *Conn) LocalAddr() net.Addr {
 	if c.localAddr != nil {
 		return c.localAddr
@@ -124,7 +124,7 @@ func (c *Conn) LocalAddr() net.Addr {
 	return c.Conn.LocalAddr()
 }
 
-// Return the specified remote addr, if there is one.
+// RemoteAddr returns the specified remote addr, if there is one.
 func (c *Conn) RemoteAddr() net.Addr {
 	if c.remoteAddr != nil {
 		return c.remoteAddr


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?