### PR TITLE
Update to v0.16.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Version number
-const Version = "0.15.0"
+const Version = "0.16.0"
 
 var message = `<!DOCTYPE html><html>
 <head>


### PR DESCRIPTION
Nothing in code changes, but update release for Go 1.12.10 build.