### PR TITLE
Remove `tcpKeepAliveListener`

### DIFF
--- a/proxyprotocol/http.go
+++ b/proxyprotocol/http.go
@@ -4,27 +4,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
-	"time"
 )
-
-// Copied verbatim from net/http's server.go.
-// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
-// connections. It's used by ListenAndServe and ListenAndServeTLS so
-// dead TCP connections (e.g. closing laptop mid-download) eventually
-// go away.
-type tcpKeepAliveListener struct {
-	*net.TCPListener
-}
-
-func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
-	tc, err := ln.AcceptTCP()
-	if err != nil {
-		return
-	}
-	tc.SetKeepAlive(true)
-	tc.SetKeepAlivePeriod(3 * time.Minute)
-	return tc, nil
-}
 
 func BehindTCPProxyListenAndServeTLS(srv *http.Server, certFile, keyFile string) error {
 	// Begin copied almost verbatim from net/http
@@ -53,7 +33,7 @@ func BehindTCPProxyListenAndServeTLS(srv *http.Server, certFile, keyFile string)
 
 	// Wrap the listener with one understanding the PROXY protocol
 	var listener net.Listener
-	listener = tcpKeepAliveListener{ln.(*net.TCPListener)}
+	listener = ln.(*net.TCPListener)
 	listener = NewListener(listener)
 	listener = tls.NewListener(listener, srv.TLSConfig)
 	return srv.Serve(listener)
@@ -75,7 +55,7 @@ func BehindTCPProxyListenAndServe(srv *http.Server) error {
 	// End copied verbatim from net/http
 
 	// Wrap the listener with one understanding the PROXY protocol
-	listener := NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)})
+	listener := NewListener(ln.(*net.TCPListener))
 	return srv.Serve(listener)
 }
 


### PR DESCRIPTION
From Go 1.13, this code was removed from the Go source. Instead, a
`net.TCPListener` has a configurable `KeepAlive`, which defaults to
`net.defaultTCPKeepAlive`. This is currently set to 15 seconds, as of Go
1.15. (It was originally set as 3 minutes, because the code was
copy-pasted from Go's source.)

This change simplifies our code and changes our server behaviour to be
consistent with the default in Go, which is also the behaviour in the
calls to `http.Server.ListenAndServe()` that we use in main.go.

See golang/go#23378 and golang/go#31510.