### PR TITLE
Update to Go 1.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-alpine
+FROM golang:1.18.2-alpine
 
 # Turn off cgo for a more static binary.
 # Specify cache directory so that we can run as nobody to build the binary.
@@ -12,4 +12,4 @@ COPY go.mod ./
 RUN go mod download
 
 COPY . .
-RUN go install -v
+RUN go install -v -buildvcs=false

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sensiblecodeio/tiny-ssl-reverse-proxy
 
-go 1.16
+go 1.18


### PR DESCRIPTION
Use `-buildvcs=false` for now to retain previous build behaviour, and
not require Git. We can revisit this later.