### PR TITLE
Fix the quick check of the binary in CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run and test redirect
         run: |
           ./tiny-ssl-reverse-proxy -key key.pem -cert crt.pem &
-          curl -v https://localhost:443 2>&1 | grep "self signed certificate"
+          curl --cacert crt.pem https://localhost:443 | grep "Backend Unavailable"


### PR DESCRIPTION
Think the `curl` error changed; let's actually use the same certificate to actually check everything works end-to-end.